### PR TITLE
Add code for installing R 3.2

### DIFF
--- a/r_provisioner.sh
+++ b/r_provisioner.sh
@@ -21,13 +21,7 @@ apt-get update
 export R_BASE_VERSION=3.2.0-4
 
 # ## Now install R and littler, and create a link for littler in /usr/local/bin
-apt-get install -y --no-install-recommends r-base=${R_BASE_VERSION}* r-base-dev=${R_BASE_VERSION}* r-recommended=${R_BASE_VERSION}*
-
-# New version of littler, useful for automated install
-git clone https://github.com/eddelbuettel/littler
-cd littler
-sh bootstrap && make install
-cd -
+apt-get install -y --no-install-recommends littler r-base=${R_BASE_VERSION}* r-base-dev=${R_BASE_VERSION}* r-recommended=${R_BASE_VERSION}*
 
 ln -s /root/src/littler/examples/install.r /usr/local/bin/install.r
 ln -s /root/src/littler/examples/install2.r /usr/local/bin/install2.r
@@ -42,7 +36,8 @@ install.r docopt
 ## For the R client
 apt-get install -y curl libcurl3-openssl-dev
 install.r RJSONIO RCurl digest
-echo -e '#!/usr/bin/Rscript\nsource("http://depot.sagebase.org/CRAN.R") ; pkgInstall(c("synapseClient"))' > /tmp/installsynapse.R
-Rscript /tmp/installsynapse.R
 
-rm /tmp/installsynapse.R
+echo -e '#!/usr/bin/Rscript\nsource("http://depot.sagebase.org/CRAN.R") ; pkgInstall(c("synapseClient"))' > /root/src/installsynapse.R
+Rscript /root/src/installsynapse.R
+
+rm /root/src/installsynapse.R

--- a/r_provisioner.sh
+++ b/r_provisioner.sh
@@ -16,28 +16,25 @@ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
 echo "deb http://cran.rstudio.com/bin/linux/ubuntu/ precise/" > /etc/apt/sources.list.d/r-cran.list
 apt-get update
 
-## For R 3.2, Ubuntu repositories only have R 2.14
+## For R 3.1, Ubuntu repositories only have R 2.14
 
-export R_BASE_VERSION=3.2.0-4
+export R_BASE_VERSION=3.1.3-1
 
 # ## Now install R and littler, and create a link for littler in /usr/local/bin
 apt-get install -y --no-install-recommends littler r-base=${R_BASE_VERSION}* r-base-dev=${R_BASE_VERSION}* r-recommended=${R_BASE_VERSION}*
 
-ln -s /root/src/littler/examples/install.r /usr/local/bin/install.r
-ln -s /root/src/littler/examples/install2.r /usr/local/bin/install2.r
-ln -s /root/src/littler/examples/installGithub.r /usr/local/bin/installGithub.r
-ln -s /root/src/littler/examples/testInstalled.r /usr/local/bin/testInstalled.r
+ln -s /usr/share/doc/littler/examples/install.r /usr/local/bin/install.r
+ln -s /usr/share/doc/littler/examples/install2.r /usr/local/bin/install2.r
+ln -s /usr/share/doc/littler/examples/installGithub.r /usr/local/bin/installGithub.r
+ln -s /usr/share/doc/littler/examples/testInstalled.r /usr/local/bin/testInstalled.r
 
 ## Set a default CRAN Repo
 echo 'options(repos = list(CRAN="http://cran.rstudio.com/"))' >> /etc/R/Rprofile.site
 
-install.r docopt
+r -e 'install.packages("docopt", repo="http://cran.rstudio.com/")'
 
 ## For the R client
-apt-get install -y curl libcurl3-openssl-dev
-install.r RJSONIO RCurl digest
+apt-get install -y curl libcurl4-openssl-dev
+install2.r -r http://cran.rstudio.com/ RJSONIO RCurl digest
 
-echo -e '#!/usr/bin/Rscript\nsource("http://depot.sagebase.org/CRAN.R") ; pkgInstall(c("synapseClient"))' > /root/src/installsynapse.R
-Rscript /root/src/installsynapse.R
-
-rm /root/src/installsynapse.R
+r -e 'source("http://depot.sagebase.org/CRAN.R") ; pkgInstall(c("synapseClient"))'

--- a/r_provisioner.sh
+++ b/r_provisioner.sh
@@ -12,7 +12,7 @@ export LC_ALL="en_US.UTF-8"
 
 ## Use Debian repo at CRAN, and use RStudio CDN as mirror
 ## This gets us updated r-base, r-base-dev, r-recommended and littler
-apt-key adv --keyserver keys.gnupg.net --recv-key 381BA480
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
 echo "deb http://cran.rstudio.com/bin/linux/ubuntu/ precise/" > /etc/apt/sources.list.d/r-cran.list
 apt-get update
 

--- a/r_provisioner.sh
+++ b/r_provisioner.sh
@@ -16,13 +16,14 @@ apt-key adv --keyserver keys.gnupg.net --recv-key 381BA480
 echo "deb http://cran.rstudio.com/bin/linux/ubuntu/ precise/" > /etc/apt/sources.list.d/r-cran.list
 apt-get update
 
-## For R 3.2
+## For R 3.2, Ubuntu repositories only have R 2.14
 
 export R_BASE_VERSION=3.2.0-4
 
 # ## Now install R and littler, and create a link for littler in /usr/local/bin
 apt-get install -y --no-install-recommends r-base=${R_BASE_VERSION}* r-base-dev=${R_BASE_VERSION}* r-recommended=${R_BASE_VERSION}*
 
+# New version of littler, useful for automated install
 git clone https://github.com/eddelbuettel/littler
 cd littler
 sh bootstrap && make install

--- a/r_provisioner.sh
+++ b/r_provisioner.sh
@@ -28,13 +28,16 @@ ln -s /usr/share/doc/littler/examples/install2.r /usr/local/bin/install2.r
 ln -s /usr/share/doc/littler/examples/installGithub.r /usr/local/bin/installGithub.r
 ln -s /usr/share/doc/littler/examples/testInstalled.r /usr/local/bin/testInstalled.r
 
-## Set a default CRAN Repo
-echo 'options(repos = list(CRAN="http://cran.rstudio.com/"))' >> /etc/R/Rprofile.site
+## Set a default CRAN repo
+echo 'options(repo = list(CRAN="http://cran.rstudio.com/"))' >> /etc/R/Rprofile.site
 
-r -e 'install.packages("docopt", repo="http://cran.rstudio.com/")'
+## Use the default CRAN repo with littler
+echo 'source("/etc/R/Rprofile.site")' >> /etc/littler.r
+
+install.r docopt
 
 ## For the R client
 apt-get install -y curl libcurl4-openssl-dev
-install2.r -r http://cran.rstudio.com/ RJSONIO RCurl digest
+install.r RJSONIO RCurl digest
 
 r -e 'source("http://depot.sagebase.org/CRAN.R") ; pkgInstall(c("synapseClient"))'

--- a/r_provisioner.sh
+++ b/r_provisioner.sh
@@ -1,6 +1,42 @@
 #!/bin/bash -x
 
-pip install synapseclient
+mkdir /root/src/
+cd /root/src/
+
+## Configure default locale, see https://github.com/rocker-org/rocker/issues/19
+echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+locale-gen en_US.utf8
+/usr/sbin/update-locale LANG=en_US.UTF-8
+
+export LC_ALL="en_US.UTF-8"
+
+## Use Debian repo at CRAN, and use RStudio CDN as mirror
+## This gets us updated r-base, r-base-dev, r-recommended and littler
+apt-key adv --keyserver keys.gnupg.net --recv-key 381BA480
+echo "deb http://cran.rstudio.com/bin/linux/ubuntu/ precise/" > /etc/apt/sources.list.d/r-cran.list
+apt-get update
+
+## For R 3.2
+
+export R_BASE_VERSION=3.2.0-4
+
+# ## Now install R and littler, and create a link for littler in /usr/local/bin
+apt-get install -y --no-install-recommends r-base=${R_BASE_VERSION}* r-base-dev=${R_BASE_VERSION}* r-recommended=${R_BASE_VERSION}*
+
+git clone https://github.com/eddelbuettel/littler
+cd littler
+sh bootstrap && make install
+cd -
+
+ln -s /root/src/littler/examples/install.r /usr/local/bin/install.r
+ln -s /root/src/littler/examples/install2.r /usr/local/bin/install2.r
+ln -s /root/src/littler/examples/installGithub.r /usr/local/bin/installGithub.r
+ln -s /root/src/littler/examples/testInstalled.r /usr/local/bin/testInstalled.r
+
+## Set a default CRAN Repo
+echo 'options(repos = list(CRAN="http://cran.rstudio.com/"))' >> /etc/R/Rprofile.site
+
+install.r docopt
 
 ## For the R client
 apt-get install -y curl libcurl3-openssl-dev


### PR DESCRIPTION
Ubuntu 12.04 only has `R 2.14`, that's waaay old. Added code to pull from a different package repo (from RStudio's mirror) and install `R 3.2.0-4` and `littler`.
